### PR TITLE
Fix path in Wal::get_config

### DIFF
--- a/src/wal.rs
+++ b/src/wal.rs
@@ -95,7 +95,7 @@ text               = {cursor.strip}"#;
     }
 
     pub fn get_config(&self) -> String {
-        let path = &self.cache_path;
+        let path = &self.config_path;
         let file = match File::open(&path) {
             Ok(f) => f,
             Err(e) => panic!("Error opening colors-spicetify.ini! {}", e),


### PR DESCRIPTION
I think you meant tou put `config_path` in `get_path`, because before changing to this, it wasn't working
