### PR TITLE
fixes for when you use a file to generate colors insted of a picture

### DIFF
--- a/src/wal.rs
+++ b/src/wal.rs
@@ -21,7 +21,7 @@ impl Wal {
 
     pub fn reload(&self) {
         let _ = process::Command::new("wal")
-            .arg("-w")
+            .arg("-n")
             .output()
             .expect("Failed run wal");
     }


### PR DESCRIPTION
when you use command wal -f to generate colors it changes your background to some random album art. this is a fix for it. 

# this commit fixes #10 