### PR TITLE
Added support for --no-restart flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,13 @@ fn main() {
                 .long("reset")
                 .action(clap::ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("no-restart")
+                .short('n')
+                .long("no-restart")
+                .action(clap::ArgAction::SetTrue)
+                .help("Don't restart Spotify if it's not running"),
+        )
         .arg_required_else_help(true)
         .get_matches();
 
@@ -36,17 +43,18 @@ fn main() {
 
     let wal = Wal::new(home.clone());
     let spicetify = Spicetify::new(home.clone(), &theme);
+    let use_no_restart = matches.get_flag("no-restart");
 
     if matches.get_flag("reset") {
         println!("Resetting configs...");
         wal.reset();
         spicetify.write_config(None);
-        spicetify.reload();
+        spicetify.reload(use_no_restart);
     } else {
         wal.set_config();
         let wal_config = wal.get_config();
 
         spicetify.write_config(Some(wal_config));
-        spicetify.reload();
+        spicetify.reload(use_no_restart);
     }
 }

--- a/src/spicetify.rs
+++ b/src/spicetify.rs
@@ -7,6 +7,26 @@ pub struct Spicetify {
     config_path: PathBuf,
     theme: String,
 }
+
+fn is_spotify_running() -> bool {
+    match process::Command::new("pgrep")
+        .arg("-x")
+        .arg("spotify")
+        .output()
+    {
+        Ok(output) => output.status.success(),
+        Err(_) => {
+            match process::Command::new("ps")
+                .arg("-C")
+                .arg("spotify")
+                .output()
+            {
+                Ok(output) => output.status.success(),
+                Err(_) => false,
+            }
+        }
+    }
+}
 impl Spicetify {
     pub fn new(home: PathBuf, theme: &str) -> Self {
         let mut config_path = home;
@@ -20,7 +40,7 @@ impl Spicetify {
         }
     }
 
-    pub fn reload(&self) {
+    pub fn reload(&self, use_no_restart_flag: bool) {
         process::Command::new("spicetify")
             .arg("config")
             .arg("current_theme")
@@ -33,7 +53,15 @@ impl Spicetify {
             .arg("pywal")
             .status()
             .unwrap();
-        match process::Command::new("spicetify").arg("apply").output() {
+        
+        let mut apply_cmd = process::Command::new("spicetify");
+        apply_cmd.arg("apply");
+        
+        if use_no_restart_flag && !is_spotify_running() {
+            apply_cmd.arg("-n");
+        }
+        
+        match apply_cmd.output() {
             Ok(stdout) => {
                 println!("Running spicetify...");
                 if let Ok(output) = String::from_utf8(stdout.stdout) {


### PR DESCRIPTION
Spicetify support this flag.
When specified, Spotify will not reload if it is not running otherwise, the behavior remains unchanged.